### PR TITLE
Separate Caddy docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ temp/
 # Generated files
 n8n-docker-compose.yaml
 flowise-docker-compose.yaml
-Caddyfile 
+Caddyfile
+caddy-docker-compose.yaml

--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Login credentials will be displayed at the end of the installation process.
   - `04-generate-secrets.sh` - secret key generation
   - `05-create-templates.sh` - configuration file creation
   - `06-setup-firewall.sh` - firewall setup
-  - `07-start-services.sh` - service launch
-- `n8n-docker-compose.yaml.template` - docker-compose template for n8n and Caddy
+- `07-start-services.sh` - service launch
+- `n8n-docker-compose.yaml.template` - docker-compose template for n8n
+- `caddy-docker-compose.yaml.template` - docker-compose template for Caddy
 - `flowise-docker-compose.yaml.template` - docker-compose template for Flowise
 
 ## Managing services
@@ -79,6 +80,7 @@ Login credentials will be displayed at the end of the installation process.
 
 ```bash
 docker compose -f n8n-docker-compose.yaml restart
+docker compose -f caddy-docker-compose.yaml restart
 docker compose -f flowise-docker-compose.yaml restart
 ```
 
@@ -86,6 +88,7 @@ docker compose -f flowise-docker-compose.yaml restart
 
 ```bash
 docker compose -f n8n-docker-compose.yaml down
+docker compose -f caddy-docker-compose.yaml down
 docker compose -f flowise-docker-compose.yaml down
 ```
 
@@ -93,6 +96,7 @@ docker compose -f flowise-docker-compose.yaml down
 
 ```bash
 docker compose -f n8n-docker-compose.yaml logs
+docker compose -f caddy-docker-compose.yaml logs
 docker compose -f flowise-docker-compose.yaml logs
 ```
 

--- a/caddy-docker-compose.yaml.template
+++ b/caddy-docker-compose.yaml.template
@@ -1,0 +1,25 @@
+version: '3'
+
+volumes:
+  caddy_data:
+    external: true
+  caddy_config:
+
+services:
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /opt/n8n/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    external: true

--- a/n8n-docker-compose.yaml.template
+++ b/n8n-docker-compose.yaml.template
@@ -3,9 +3,6 @@ version: '3'
 volumes:
   n8n_data:
     external: true
-  caddy_data:
-    external: true
-  caddy_config:
 
 services:
   n8n:
@@ -33,19 +30,6 @@ services:
     networks:
       - app-network
 
-  caddy:
-    image: caddy:2
-    container_name: caddy
-    restart: unless-stopped
-    ports:
-      - 80:80
-      - 443:443
-    volumes:
-      - /opt/n8n/Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
-    networks:
-      - app-network
 
 networks:
   app-network:

--- a/setup-files/05-create-templates.sh
+++ b/setup-files/05-create-templates.sh
@@ -20,9 +20,6 @@ version: '3'
 volumes:
   n8n_data:
     external: true
-  caddy_data:
-    external: true
-  caddy_config:
 
 services:
   n8n:
@@ -41,20 +38,6 @@ services:
     volumes:
       - n8n_data:/home/node/.n8n
       - /opt/n8n/files:/files
-    networks:
-      - app-network
-
-  caddy:
-    image: caddy:2
-    container_name: caddy
-    restart: unless-stopped
-    ports:
-      - 80:80
-      - 443:443
-    volumes:
-      - /opt/n8n/Caddyfile:/etc/caddy/Caddyfile
-      - caddy_data:/data
-      - caddy_config:/config
     networks:
       - app-network
 
@@ -102,6 +85,43 @@ else
   echo "Template flowise-docker-compose.yaml.template already exists"
 fi
 
+if [ ! -f "caddy-docker-compose.yaml.template" ]; then
+  echo "Creating template caddy-docker-compose.yaml.template..."
+  cat > caddy-docker-compose.yaml.template << EOL
+version: '3'
+
+volumes:
+  caddy_data:
+    external: true
+  caddy_config:
+
+services:
+  caddy:
+    image: caddy:2
+    container_name: caddy
+    restart: unless-stopped
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - /opt/n8n/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    external: true
+EOL
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to create file caddy-docker-compose.yaml.template"
+    exit 1
+  fi
+else
+  echo "Template caddy-docker-compose.yaml.template already exists"
+fi
+
 # Copy templates to working files
 cp n8n-docker-compose.yaml.template n8n-docker-compose.yaml
 if [ $? -ne 0 ]; then
@@ -112,6 +132,12 @@ fi
 cp flowise-docker-compose.yaml.template flowise-docker-compose.yaml
 if [ $? -ne 0 ]; then
   echo "ERROR: Failed to copy flowise-docker-compose.yaml.template to working file"
+  exit 1
+fi
+
+cp caddy-docker-compose.yaml.template caddy-docker-compose.yaml
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to copy caddy-docker-compose.yaml.template to working file"
   exit 1
 fi
 

--- a/setup-files/07-start-services.sh
+++ b/setup-files/07-start-services.sh
@@ -13,16 +13,21 @@ if [ ! -f "flowise-docker-compose.yaml" ]; then
   exit 1
 fi
 
+if [ ! -f "caddy-docker-compose.yaml" ]; then
+  echo "ERROR: File caddy-docker-compose.yaml not found"
+  exit 1
+fi
+
 if [ ! -f ".env" ]; then
   echo "ERROR: File .env not found"
   exit 1
 fi
 
-# Start n8n and Caddy
-echo "Starting n8n and Caddy..."
+# Start n8n
+echo "Starting n8n..."
 sudo docker compose -f n8n-docker-compose.yaml up -d
 if [ $? -ne 0 ]; then
-  echo "ERROR: Failed to start n8n and Caddy"
+  echo "ERROR: Failed to start n8n"
   exit 1
 fi
 
@@ -33,6 +38,14 @@ sleep 5
 # Check if app-network was created
 if ! sudo docker network inspect app-network &> /dev/null; then
   echo "ERROR: Failed to create app-network"
+  exit 1
+fi
+
+# Start Caddy
+echo "Starting Caddy..."
+sudo docker compose -f caddy-docker-compose.yaml up -d
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to start Caddy"
   exit 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -121,13 +121,15 @@ main() {
   echo "pointing to the IP address of this server."
   echo ""
   echo "To edit the configuration, use the following files:"
-  echo "- n8n-docker-compose.yaml (n8n and Caddy configuration)"
+  echo "- n8n-docker-compose.yaml (n8n configuration)"
+  echo "- caddy-docker-compose.yaml (Caddy configuration)"
   echo "- flowise-docker-compose.yaml (Flowise configuration)"
   echo "- .env (environment variables for all services)"
   echo "- Caddyfile (reverse proxy settings)"
   echo ""
   echo "To restart services, execute the commands:"
   echo "docker compose -f n8n-docker-compose.yaml restart"
+  echo "docker compose -f caddy-docker-compose.yaml restart"
   echo "docker compose -f flowise-docker-compose.yaml restart"
 }
 


### PR DESCRIPTION
## Summary
- split Caddy out of the n8n compose file
- generate new caddy-docker-compose.yaml template
- update service start script to launch n8n, Caddy and Flowise separately
- document new compose file and commands in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a6d0035d483299fdfdc2f6f2204a4