### PR TITLE
Add service update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Login credentials will be displayed at the end of the installation process.
 - `n8n-docker-compose.yaml.template` - docker-compose template for n8n
 - `caddy-docker-compose.yaml.template` - docker-compose template for Caddy
 - `flowise-docker-compose.yaml.template` - docker-compose template for Flowise
+- `update-all.sh` - update all services
+- `update-files/` - directory with update scripts:
+  - `update-n8n.sh` - update n8n
+  - `update-flowise.sh` - update Flowise
+  - `update-caddy.sh` - update Caddy
 
 ## Managing services
 
@@ -98,6 +103,18 @@ docker compose -f flowise-docker-compose.yaml down
 docker compose -f n8n-docker-compose.yaml logs
 docker compose -f caddy-docker-compose.yaml logs
 docker compose -f flowise-docker-compose.yaml logs
+```
+
+### Updating services
+
+Update scripts are stored in the `update-files/` directory. You can update a
+single service or all of them at once:
+
+```bash
+./update-files/update-n8n.sh      # update only n8n
+./update-files/update-flowise.sh  # update only Flowise
+./update-files/update-caddy.sh    # update only Caddy
+./update-all.sh                   # update everything
 ```
 
 ## Security

--- a/update-all.sh
+++ b/update-all.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname "$0")/update-files"
+
+"$SCRIPT_DIR/update-n8n.sh" || exit 1
+"$SCRIPT_DIR/update-flowise.sh" || exit 1
+"$SCRIPT_DIR/update-caddy.sh" || exit 1
+
+echo "✅ All services successfully updated"
+exit 0

--- a/update-files/update-caddy.sh
+++ b/update-files/update-caddy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "Updating Caddy..."
+
+# Check for required files
+if [ ! -f "caddy-docker-compose.yaml" ]; then
+  echo "ERROR: File caddy-docker-compose.yaml not found"
+  exit 1
+fi
+
+# Pull latest image
+sudo docker compose -f caddy-docker-compose.yaml pull
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to pull Caddy image"
+  exit 1
+fi
+
+# Restart container
+sudo docker compose -f caddy-docker-compose.yaml up -d
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to restart Caddy"
+  exit 1
+fi
+
+echo "✅ Caddy successfully updated"
+exit 0

--- a/update-files/update-flowise.sh
+++ b/update-files/update-flowise.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "Updating Flowise..."
+
+# Check for required files
+if [ ! -f "flowise-docker-compose.yaml" ]; then
+  echo "ERROR: File flowise-docker-compose.yaml not found"
+  exit 1
+fi
+
+if [ ! -f ".env" ]; then
+  echo "ERROR: File .env not found"
+  exit 1
+fi
+
+# Pull latest image
+sudo docker compose -f flowise-docker-compose.yaml pull
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to pull Flowise image"
+  exit 1
+fi
+
+# Restart container
+sudo docker compose -f flowise-docker-compose.yaml up -d
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to restart Flowise"
+  exit 1
+fi
+
+echo "✅ Flowise successfully updated"
+exit 0

--- a/update-files/update-n8n.sh
+++ b/update-files/update-n8n.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo "Updating n8n..."
+
+# Check for required files
+if [ ! -f "n8n-docker-compose.yaml" ]; then
+  echo "ERROR: File n8n-docker-compose.yaml not found"
+  exit 1
+fi
+
+if [ ! -f ".env" ]; then
+  echo "ERROR: File .env not found"
+  exit 1
+fi
+
+# Pull latest image
+sudo docker compose -f n8n-docker-compose.yaml pull
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to pull n8n image"
+  exit 1
+fi
+
+# Restart container
+sudo docker compose -f n8n-docker-compose.yaml up -d
+if [ $? -ne 0 ]; then
+  echo "ERROR: Failed to restart n8n"
+  exit 1
+fi
+
+echo "✅ n8n successfully updated"
+exit 0


### PR DESCRIPTION
## Summary
- add scripts to update each service
- add a master script that calls individual update scripts
- document how to update services in README

## Testing
- `bash -n update-files/update-n8n.sh`
- `bash -n update-files/update-flowise.sh`
- `bash -n update-files/update-caddy.sh`
- `bash -n update-all.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a7179dc348329b1296ae1e9e54968