### PR TITLE
Fix repo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The system is configured to work with your domain name and automatically obtains
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/miolamio/cloud-local-n8n-flowise.git && cd cloud-local-n8n-flowise
+   git clone https://github.com/igrbdrv/cloud-local-n8n-flowise.git && cd cloud-local-n8n-flowise
    ```
 
 2. Make the script executable:


### PR DESCRIPTION
## Summary
- update repo URL in README installation instructions

## Testing
- `bash -n` on all shell scripts

------
https://chatgpt.com/codex/tasks/task_e_685bebadacf88329882a156cdad30ec4