### PR TITLE
Fix firewall script to open SSH port

### DIFF
--- a/setup-files/06-setup-firewall.sh
+++ b/setup-files/06-setup-firewall.sh
@@ -18,6 +18,12 @@ if command -v ufw &> /dev/null; then
     echo "ERROR: Failed to open port 443"
     exit 1
   fi
+
+  sudo ufw allow 22
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to open port 22"
+    exit 1
+  fi
   
   # Check if ufw is active
   sudo ufw status | grep -q "Status: active"
@@ -30,7 +36,7 @@ if command -v ufw &> /dev/null; then
     fi
   fi
   
-  echo "Ports 80 and 443 are open in the firewall"
+  echo "Ports 80, 443 and 22 are open in the firewall"
 else
   echo "UFW is not installed. Installing..."
   sudo apt-get install -y ufw
@@ -51,6 +57,12 @@ else
     echo "ERROR: Failed to open port 443"
     exit 1
   fi
+
+  sudo ufw allow 22
+  if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to open port 22"
+    exit 1
+  fi
   
   # Activate firewall
   sudo ufw --force enable
@@ -59,7 +71,7 @@ else
     exit 1
   fi
   
-  echo "Firewall installed and ports 80, 443 are open"
+  echo "Firewall installed and ports 80, 443 and 22 are open"
 fi
 
 echo "✅ Firewall successfully configured"


### PR DESCRIPTION
## Summary
- open port 22 for SSH in firewall setup
- update log messages to include port 22

## Testing
- `bash -n setup-files/06-setup-firewall.sh`

------
https://chatgpt.com/codex/tasks/task_e_6878b02cea648329a30469c8344fafd1